### PR TITLE
[PLTF-1534] Created a customized Helm chart for aws-cloudwatch-metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+*.tgz
 
 # Test binary, build with `go test -c`
 *.test

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ build/
 .idea
 *.iml
 charts/
+test-values.yaml

--- a/stable/aws-cloudwatch-metrics/.helmignore
+++ b/stable/aws-cloudwatch-metrics/.helmignore
@@ -21,3 +21,4 @@
 .idea/
 *.tmproj
 .vscode/
+test-values.yaml

--- a/stable/aws-cloudwatch-metrics/templates/cluster-info.tpl
+++ b/stable/aws-cloudwatch-metrics/templates/cluster-info.tpl
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  cluster.name: {{ .Values.clusterName }}
+  logs.region: {{ .Values.clusterRegion }}
+kind: ConfigMap
+metadata:
+  name: cluster-info
+  namespace: {{ .Release.Namespace }}

--- a/stable/aws-cloudwatch-metrics/templates/configmap.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/configmap.yaml
@@ -15,7 +15,7 @@ data:
           "kubernetes": {
             "cluster_name": "{{ .Values.clusterName }}",
             "enhanced_container_insights": {{ .Values.enhancedContainerInsights.enabled }},
-            "tag_service": {{ .Values.config.tagService }},
+            "tag_service": {{ .Values.tagService }},
             "disable_metric_extraction": {{ .Values.disableMetricExtraction }},
             "metrics_collection_interval": {{ .Values.collectionInterval }}
           }

--- a/stable/aws-cloudwatch-metrics/templates/configmap.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/configmap.yaml
@@ -7,12 +7,17 @@ metadata:
 data:
   cwagentconfig.json: |
     {
+      "agent": {
+        "region": "{{ .Values.clusterRegion }}"
+      },
       "logs": {
         "metrics_collected": {
           "kubernetes": {
             "cluster_name": "{{ .Values.clusterName }}",
             "enhanced_container_insights": {{ .Values.enhancedContainerInsights.enabled }},
-            "metrics_collection_interval": 60
+            "tag_service": {{ .Values.config.tagService }},
+            "disable_metric_extraction": {{ .Values.disableMetricExtraction }},
+            "metrics_collection_interval": {{ .Values.collectionInterval }}
           }
         },
         "force_flush_interval": 5

--- a/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         # Please don't change below envs
         env:
         - name: RUN_WITH_IRSA
-          value: '{{ .Values.runWithIRSA }}'
+          value: {{ .Values.runWithIRSA }}
         - name: HOST_IP
           valueFrom:
             fieldRef:

--- a/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         # Please don't change below envs
         env:
         - name: RUN_WITH_IRSA
-          value: {{ .Values.runWithRSA }}
+          value: '{{ .Values.runWithIRSA }}'
         - name: HOST_IP
           valueFrom:
             fieldRef:

--- a/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/daemonset.yaml
@@ -22,6 +22,8 @@ spec:
         {{- include "aws-cloudwatch-metrics.statsdConfig" . | nindent 8 -}}
         # Please don't change below envs
         env:
+        - name: RUN_WITH_IRSA
+          value: {{ .Values.runWithRSA }}
         - name: HOST_IP
           valueFrom:
             fieldRef:

--- a/stable/aws-cloudwatch-metrics/templates/serviceaccount.yaml
+++ b/stable/aws-cloudwatch-metrics/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "aws-cloudwatch-metrics.serviceAccountName" . }}
+  name: {{ include "aws-cloudwatch-metrics.fullname" . }}
   labels:
     {{- include "aws-cloudwatch-metrics.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -3,15 +3,15 @@ image:
   tag: 1.300032.2b361
   pullPolicy: IfNotPresent
 
-clusterName: "kaas-staging"
-clusterRegion: "eu-west-1"
+clusterName: ""
+clusterRegion: ""
 
 enhancedContainerInsights:
   enabled: true
 
 disableMetricExtraction: false
 
-collectionInterval: 120
+collectionInterval: 60
 tagService: false
 
 resources:

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -3,15 +3,16 @@ image:
   tag: 1.300032.2b361
   pullPolicy: IfNotPresent
 
-clusterName: cluster_name
-clusterRegion: ""
+clusterName: "kaas-staging"
+clusterRegion: "eu-west-1"
 
 enhancedContainerInsights:
   enabled: true
 
 disableMetricExtraction: false
 
-collectionInterval: 60
+collectionInterval: 120
+tagService: false
 
 resources:
   limits:
@@ -23,6 +24,8 @@ resources:
 
 serviceAccount:
   create: true
+#  annotations:
+#    eks.amazonaws.com/role-arn: arn:aws:iam::11111:role/***
   name:
 
 hostNetwork: false
@@ -31,7 +34,9 @@ runWithIRSA: false
 
 nodeSelector: {}
 
-tolerations: []
+tolerations:
+  - key:
+    operator: Exists
 
 affinity: {}
 

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -30,7 +30,7 @@ serviceAccount:
 
 hostNetwork: false
 
-runWithIRSA: 'False'
+runWithIRSA: "False"
 
 nodeSelector: {}
 

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -30,7 +30,7 @@ serviceAccount:
 
 hostNetwork: false
 
-runWithIRSA: false
+runWithIRSA: 'False'
 
 nodeSelector: {}
 

--- a/stable/aws-cloudwatch-metrics/values.yaml
+++ b/stable/aws-cloudwatch-metrics/values.yaml
@@ -4,9 +4,14 @@ image:
   pullPolicy: IfNotPresent
 
 clusterName: cluster_name
+clusterRegion: ""
 
 enhancedContainerInsights:
   enabled: true
+
+disableMetricExtraction: false
+
+collectionInterval: 60
 
 resources:
   limits:
@@ -21,6 +26,8 @@ serviceAccount:
   name:
 
 hostNetwork: false
+
+runWithIRSA: false
 
 nodeSelector: {}
 


### PR DESCRIPTION

## Description

This chart includes configuration settings that disables extended metrics (enabled by default in AWS's official distribution) which are very costly and not required for Anodot's solution for usage and costs analysis.

## Changes

* Added RUN_WITH_IRSA environment variable to tell the agent to authenticate using IRSA.
* Added configurations recommended by Anodot.

## Instructions

Authenticate with ECR (SB-DEV):

`aws ecr get-login-password --region eu-west-1 | helm registry login --username AWS --password-stdin 551806661322.dkr.ecr.eu-west-1.amazonaws.com`


To build run:

```
helm package .
helm push aws-cloudwatch-metrics-0.0.11.tgz oci://551806661322.dkr.ecr.eu-west-1.amazonaws.com
```


